### PR TITLE
feat: visual selection string is transcriped instead of visual lines.

### DIFF
--- a/autoload/latexencode.vim
+++ b/autoload/latexencode.vim
@@ -1,13 +1,44 @@
-function! latexencode#latexencode(start, end) abort
-  normal! m`
-  " convert unicode symbols to LaTeX commands
-  keepjumps exe a:start . ',' . a:end . '!latexencode --quiet'
-  normal! g``
+" From: https://stackoverflow.com/a/28398359/1827360
+function! latexencode#get_visual_selection(mode)
+    " call with visualmode() as the argument
+    let [line_start, column_start] = getpos("'<")[1:2]
+    let [line_end, column_end]     = getpos("'>")[1:2]
+    let lines = getline(line_start, line_end)
+    if a:mode ==# 'v'
+        " Must trim the end before the start, the beginning will shift left.
+        let lines[-1] = lines[-1][: column_end - (&selection == 'inclusive' ? 1 : 2)]
+        let lines[0] = lines[0][column_start - 1:]
+    elseif  a:mode ==# 'V'
+        " Line mode no need to trim start or end
+    elseif  a:mode == "\<c-v>"
+        " Block mode, trim every line
+        let new_lines = []
+        let i = 0
+        for line in lines
+            let lines[i] = line[column_start - 1: column_end - (&selection == 'inclusive' ? 1 : 2)]
+            let i = i + 1
+        endfor
+    else
+        return ''
+    endif
+    for line in lines
+        echom line
+    endfor
+    return join(lines, "\n")
 endfunction
 
-function! latexencode#latex2text(start, end) abort
-  normal! m`
-  " convert unicode symbols to LaTeX commands
-  keepjumps exe a:start . ',' . a:end . '!latex2text --quiet'
-  normal! g``
+function! latexencode#latextranscode(cmd) abort
+  let selected_text = latexencode#get_visual_selection(visualmode())
+  let encoded_text = trim(system('echo '.shellescape(selected_text).' | '.a:cmd))
+
+  :execute "'<,'>s/".escape(selected_text, '\')."/".escape(encoded_text, '\')."/"
+  redraw
+endfunction
+
+function! latexencode#latexencode() abort
+  call latexencode#latextranscode('latexencode --quiet')
+endfunction
+
+function! latexencode#latex2text() abort
+  call latexencode#latextranscode('latex2text --quiet')
 endfunction

--- a/autoload/latexencode.vim
+++ b/autoload/latexencode.vim
@@ -21,15 +21,13 @@ function! latexencode#get_visual_selection(mode)
     else
         return ''
     endif
-    for line in lines
-        echom line
-    endfor
     return join(lines, "\n")
 endfunction
 
 function! latexencode#latextranscode(cmd) abort
   let selected_text = latexencode#get_visual_selection(visualmode())
-  let encoded_text = trim(system('echo '.shellescape(selected_text).' | '.a:cmd))
+  let command = "echo \"".selected_text->substitute('\\', '\\\\\', "g")."\" | ".a:cmd
+  let encoded_text = trim(system(command))
 
   :execute "'<,'>s/".escape(selected_text, '\')."/".escape(encoded_text, '\')."/"
   redraw

--- a/plugin/latexencode.vim
+++ b/plugin/latexencode.vim
@@ -6,7 +6,7 @@ if !executable('latexencode')
   finish
 endif
 
-command! -range LatexEncode call latexencode#latexencode(<line1>, <line2>)
-command! -range Latex2Text  call latexencode#latex2text(<line1>, <line2>)
+command! -range LatexEncode call latexencode#latexencode()
+command! -range Latex2Text  call latexencode#latex2text()
 
 let g:loaded_latexencode = 1


### PR DESCRIPTION
As per Issue #2.

### Discussion points
* I absolutely hate that vim doesn't have a built-in to get a visual selection as a string. I'm almost embarrassed by it. In Neovim, we have a library called `plenary.nvim` that is standard and contains utility functions. I wonder if there is something similar for plain vim, that can be used as a dependency?
* If there were such a library, would you be okay with adding a dependency, or would you want to keep the function I borrowed from stack overflow?
* Do you have a better way? I feel like my approach is clumsy.

### Issues
I ran into a bug when converting the authors in the enclosing braces. 
```bibtex
  author = {Stephen Lack and Ji{\v{r}}{\'i} Rosick{\'y}},
```
But when I `vi}` to select the authors and `:'<,'>Latex2Text` I get
```bibtex
  author = {Stephen Lack and Jirí Rosický},
```
or (in my buffer it reads)
```bibtex
  author = {Stephen Lack and Ji^Krí Rosický},
```
I'm not sure if the issue is related to `latexencode` or if the endocding is getting screwed up in my handling of strings. But it has worked fine with a half-dozen or so other entries.